### PR TITLE
Allow to use [hash] on importScripts.

### DIFF
--- a/index.js
+++ b/index.js
@@ -87,6 +87,10 @@ class SWPrecacheWebpackDevPlugin {
 			// @TODO: May it change to process.cwd()
 			this.opts.context = compiler.context;
 
+		const scripts = this.opts.importScripts || [];
+		const importScripts = scripts.map(f => f.replace(/\[hash\]/g, compilation.hash));
+		this.opts.importScripts = importScripts;
+
 			precache(compilation.assets, this.opts).then(sw => {
 				const filepath = path.join(compiler.options.output.path, this.opts.filename);
 				compiler.outputFileSystem.writeFile(filepath, sw, done);


### PR DESCRIPTION
The [sw-precache-webpack-plugin](https://github.com/goldhand/sw-precache-webpack-plugin/) has support for [passing the hash](https://github.com/goldhand/sw-precache-webpack-plugin/pull/20) that is generated by webpack to the importScripts option, so that service worker file names can be specified the following way:

```javascript
new SWPrecacheWebpackDevPlugin({
  importScripts: ['service-worker.[hash].js']
})
```

I've added similar functionality to the _SWPrecacheWebpackDevPlugin_ to allow testing imported scripts generated by webpack in a Dev environment.
 